### PR TITLE
Plugin, Tests, Overhaul, Many more features

### DIFF
--- a/Model/Behavior/CopyableBehavior.php
+++ b/Model/Behavior/CopyableBehavior.php
@@ -10,8 +10,21 @@
  * records are recursively copied as well.
  *
  * Usage is straightforward:
- * From model: $this->copy($id); // id = the id of the record to be copied
- * From container: $this->MyModel->copy($id);
+ *   $id = the id of the record to be copied (int or uuid)
+ *
+ * From model:
+ *   $this->copy($id);
+ * From controller:
+ *   $this->MyModel->copy($id);
+ *
+ * Primary Public Method:
+ *   copy($id, $settings)   --> $saved
+ *
+ * Secondary Public Methods:
+ *   copyGenerateContain()  --> $contain (from settings, or generated)
+ *   copyFindData($id)      --> $data    (find first w/ contains)
+ *   copyPrepareData($data) --> $data    (convert data w/o foreignKey/stripFields)
+ *   copySaveAll($data)     --> $saved   (do saveAll and update masterKey)
  *
  * @filesource
  * @author			Jamie Nay
@@ -27,24 +40,14 @@ class CopyableBehavior extends ModelBehavior {
 	public $settings = array();
 
 /**
- * Array of contained models.
- */
-	public $contain = array();
-
-/**
- * The full results of Model::find() that are modified and saved
- * as a new copy.
- */
-	public $record = array();
-
-/**
  * Default values for settings.
  *
  * - recursive: whether to copy hasMany and hasOne records
  * - habtm: whether to copy hasAndBelongsToMany associations
  * - stripFields: fields to strip during copy process
  * - ignore: aliases of any associations that should be ignored, using dot (.) notation.
- * will look in the $this->contain array.
+ * - saveAllOptions: options for saveAll()
+ * - masterKey: if set to a field, will update all records with the new id
  */
 	protected $_defaults = array(
 		'recursive' => true,
@@ -57,6 +60,10 @@ class CopyableBehavior extends ModelBehavior {
 			'rght'
 		),
 		'ignore' => array(
+		),
+		'saveAllOptions' => array(
+			'validate' => false,
+			'deep' => true
 		),
 		'masterKey' => null
 	);
@@ -74,128 +81,280 @@ class CopyableBehavior extends ModelBehavior {
 	}
 
 /**
+ * Get settings and merge in any custom "run time" overrides
+ *
+ * @param object $Model Model object
+ * @param array $settings Config array
+ * @return array $settings
+ */
+	public function settings(Model $Model, $settings = array()) {
+		return array_merge(
+			$this->_defaults,
+			// when we start copy, we set these "sticky" settings for this run
+			(!empty($this->settings['copyRunning']) ? $this->settings['copyRunning'] : array()),
+			// Model specific settings, overwrite "sticky" settings
+			(!empty($this->settings[$Model->alias]) ? $this->settings[$Model->alias] : array()),
+			// anything passed into this function always wins/overwrites
+			$settings
+		);
+	}
+
+/**
  * Copy method.
  *
  * @param object $Model model object
  * @param mixed $id String or integer model ID
+ * @param array $settings optionally pass in custom settings
  * @return boolean
  */
-	public function copy(Model $Model, $id) {
-		$this->generateContain($Model);
-		$this->record = $Model->find('first', array(
-			'conditions' => array(
-				$Model->escapeField() => $id
-			), 
-			'contain' => $this->contain
-		));
+	public function copy(Model $Model, $id, $settings = array()) {
+		// clear the "sticky" settings for copyRunning
+		$this->settings['copyRunning'] = array();
+		// get the clean list of settings for the parent Model + runtime settings
+		$settings = $this->settings($Model, $settings);
+		// set the "sticky" settings for copyRunning
+		$this->settings['copyRunning'] = $settings;
 
-		if (empty($this->record)) {
+		// get data
+		$record = $Model->copyFindData($id, $settings);
+		// stash a copy of this record before prepare
+		$Model->copyData['beforePrepare'] = $record;
+
+		// prepare / convert data
+		$record = $this->copyPrepareData($Model, $record);
+
+		// stash a copy of this record after prepare
+		$Model->copyData['afterPrepare'] = $record;
+
+		if (empty($record)) {
+			$this->log("Copy of $id resulted in empty data, after convertion");
 			return false;
 		}
 
-		if (!$this->_convertData($Model)) {
-			return false;
-		}
-
-		return $this->_copyRecord($Model);
+		// save data
+		return $this->copySaveAll($Model, $record);
 	}
 
 /**
- * Wrapper method that combines the results of _recursiveChildContain()
- * with the models' HABTM associations.
- *
- * @param object $Model Model object
- * @return array
- */
-	public function generateContain(Model $Model) {
-		if (!$this->_verifyContainable($Model)) {
-			return false;
-		}
-
-		$this->contain = array_merge($this->_recursiveChildContain($Model), array_keys($Model->hasAndBelongsToMany));
-		$this->_removeIgnored($Model);
-		return $this->contain;
-	}
-
-/**
- * Removes any ignored associations, as defined in the model settings, from
- * the $this->contain array.
- *
- * @param object $Model Model object
- * @return boolean
- */
-	protected function _removeIgnored(Model $Model) {
-		if (!$this->settings[$Model->alias]['ignore']) {
-			return true;
-		}
-		$ignore = array_unique($this->settings[$Model->alias]['ignore']);
-		foreach ($ignore as $path) {
-			if (Hash::check($this->contain, $path)) {
-				$this->contain = Hash::remove($this->contain, $path);
-			}
-		}
-		return true;
-	}
-
-/**
- * Strips primary keys and other unwanted fields
- * from hasOne and hasMany records.
+ * Find first on the Model with the contain for copy
+ * Used by copy()
+ * Used by _updateMasterKey()
  *
  * @param object $Model model object
- * @param array $record
- * @return array $record
+ * @param mixed $id String or integer model ID
+ * @param array $settings optionally pass in custom settings
+ * @return boolean
  */
-	protected function _convertChildren(Model $Model, $record) {
-		$children = array_merge($Model->hasMany, $Model->hasOne);
-		foreach ($children as $key => $val) {
-			if (!isset($record[$key])) {
-				continue;
-			}
+	public function copyFindData(Model $Model, $id, $settings = array()) {
+		$settings = $this->settings($Model, $settings);
 
-			if (empty($record[$key])) {
-				unset($record[$key]);
-				continue;
-			}
+		// clear stash of data on the Model (useful for debugging)
+		$Model->copyData = [];
+		$record = $Model->find('first', array(
+			'conditions' => array(
+				$Model->escapeField() => $id
+			),
+			'contain' => $this->copyGenerateContain($Model),
+		));
 
-			if (isset($record[$key][0])) {
-				foreach ($record[$key] as $innerKey => $innerVal) {
-					$record[$key][$innerKey] = $this->_stripFields($Model, $innerVal);
-					if (array_key_exists($val['foreignKey'], $innerVal)) {
-						unset($record[$key][$innerKey][$val['foreignKey']]);
-					}
-
-					$record[$key][$innerKey] = $this->_convertChildren($Model->{$key}, $record[$key][$innerKey]);
-				}
-			} else {
-				$record[$key] = $this->_stripFields($Model, $record[$key]);
-
-				if (isset($record[$key][$val['foreignKey']])) {
-					unset($record[$key][$val['foreignKey']]);
-				}
-
-				$record[$key] = $this->_convertChildren($Model->{$key}, $record[$key]);
-			}
+		if (empty($record)) {
+			$this->log("Copy of $id resulted in empty data, after find");
+			return false;
 		}
 
 		return $record;
 	}
 
 /**
- * Strips primary and parent foreign keys (where applicable)
- * from $this->record in preparation for saving.
+ * Wrapper method that combines the results of _generateContainHasRecursivly()
+ * with the models' HABTM associations.
  *
  * @param object $Model Model object
- * @return array $this->record
+ * @return array $contain
  */
-	protected function _convertData(Model $Model) {
-		$this->record[$Model->alias] = $this->_stripFields($Model, $this->record[$Model->alias]);
-		$this->record = $this->_convertHabtm($Model, $this->record);
-		$this->record = $this->_convertChildren($Model, $this->record);
-		return $this->record;
+	public function copyGenerateContain(Model $Model) {
+		if (!$this->_verifyContainable($Model)) {
+			return false;
+		}
+
+		// support for custom configured contain for this Model
+		$settings = $this->settings($Model);
+		if (!empty($settings['contain'])) {
+			return $settings['contain'];
+		}
+
+		// dynamically create a contains
+		$contain = array();
+		//   ignore belongsTo (no need, since field is on this Model)
+		//   recursive get hasOne and hasMany
+		$contain = $this->_generateContainHasRecursivly($Model, $contain);
+		//   get all HABTM, but not recursively
+		$contain = $this->_generateContainHABTM($Model, $contain);
+
+		$contain = $this->_generateContainRemoveIgnored($Model, $contain);
+		return $contain;
 	}
 
 /**
- * Loops through any HABTM results in $this->record and plucks out
+ * Backwards compatible alias
+ *
+ * @param object $Model Model object
+ * @return array
+ */
+	public function generateContain(Model $Model) {
+		return $this->copyGenerateContain($Model);
+	}
+
+/**
+ * Removes any ignored associations, as defined in the model settings,
+ * from the $contain array.
+ *
+ * @param object $Model Model object
+ * @param array $contain
+ * @return array $contain
+ */
+	protected function _generateContainRemoveIgnored(Model $Model, $contain) {
+		$settings = $this->settings($Model);
+
+		if (!$settings['ignore']) {
+			return $contain;
+		}
+		$ignore = array_unique($settings['ignore']);
+		foreach ($ignore as $path) {
+			if (Hash::check($contain, $path)) {
+				$contain = Hash::remove($contain, $path);
+			}
+		}
+		return $contain;
+	}
+
+/**
+ * Strips all records for belongsTo associations
+ *
+ * @param object $Model model object
+ * @param array $record
+ * @return array $record
+ */
+	protected function _convertChildrenBelongsTo(Model $Model, $record) {
+		return array_diff_key($record, $Model->belongsTo);
+	}
+
+/**
+ * Strips primary keys and other unwanted fields
+ * from hasOne
+ *
+ * @param object $Model model object
+ * @param array $record
+ * @return array $record
+ */
+	protected function _convertChildrenHasOne(Model $Model, $record) {
+		foreach ($Model->hasOne as $alias => $config) {
+			if (!isset($record[$alias])) {
+				continue;
+			}
+
+			if (empty($record[$alias])) {
+				unset($record[$alias]);
+				continue;
+			}
+
+			$record[$alias] = $this->_convertChild($Model, $record[$alias], $alias, $config);
+			if (empty($record[$alias])) {
+				unset($record[$alias]);
+			}
+		}
+		return $record;
+	}
+
+/**
+ * Strips primary keys and other unwanted fields
+ * from hasMany
+ *
+ * @param object $Model model object
+ * @param array $record
+ * @return array $record
+ */
+	protected function _convertChildrenHasMany(Model $Model, $record) {
+		foreach ($Model->hasMany as $alias => $config) {
+			if (!isset($record[$alias])) {
+				continue;
+			}
+
+			if (empty($record[$alias])) {
+				unset($record[$alias]);
+				continue;
+			}
+
+			foreach (array_keys($record[$alias]) as $i) {
+				$record[$alias][$i] = $this->_convertChild($Model, $record[$alias][$i], $alias, $config);
+				if (empty($record[$alias][$i])) {
+					unset($record[$alias][$i]);
+				}
+			}
+			if (empty($record[$alias])) {
+				unset($record[$alias]);
+			}
+		}
+		return $record;
+	}
+
+/**
+ * Strips primary keys and other unwanted fields
+ * from a single hasOne and hasMany records.
+ *
+ * @param object $Model model object
+ * @param array $data
+ * @param string $alias of the child Model
+ * @param array $config of the Association
+ * @return array $data
+ */
+	protected function _convertChild(Model $Model, $data, $alias, $config) {
+		$data = $this->_stripFields($Model, $data);
+
+		if (isset($data[$config['foreignKey']])) {
+			unset($data[$config['foreignKey']]);
+		}
+
+		$data = $this->copyPrepareData($Model->{$alias}, $data);
+
+		// is this completely empty (contains only empty values)?
+		//   if so, strip...
+		$filtered = Hash::filter($data);
+		if (empty($filtered)) {
+			return [];
+		}
+
+		return $data;
+	}
+
+/**
+ * Strips primary and parent foreign keys (where applicable)
+ * from $record in preparation for saving.
+ *
+ * @param object $Model Model object
+ * @param array $record
+ * @return array $record
+ */
+	public function copyPrepareData(Model $Model, $record) {
+		// validation
+		if (empty($record) || !is_array($record)) {
+			return array();
+		}
+		// clean this set of data
+		$record = $this->_stripFields($Model, $record);
+		if (!empty($record[$Model->alias])) {
+			$record[$Model->alias] = $this->_stripFields($Model, $record[$Model->alias]);
+		}
+		// recurse into associations, based on type
+		$record = $this->_convertHabtm($Model, $record);
+		$record = $this->_convertChildrenBelongsTo($Model, $record);
+		$record = $this->_convertChildrenHasOne($Model, $record);
+		$record = $this->_convertChildrenHasMany($Model, $record);
+		return $record;
+	}
+
+/**
+ * Loops through any HABTM results in $record and plucks out
  * the join table info, stripping out the join table primary
  * key and the primary key of $Model. This is done instead of
  * a simple collection of IDs of the associated records, since
@@ -207,55 +366,96 @@ class CopyableBehavior extends ModelBehavior {
  * @return array modified $record
  */
 	protected function _convertHabtm(Model $Model, $record) {
-		if (!$this->settings[$Model->alias]['habtm']) {
+		$settings = $this->settings($Model);
+		if (empty($settings['habtm'])) {
 			return $record;
 		}
-		foreach ($Model->hasAndBelongsToMany as $key => $val) {
-			$className = pluginSplit($val['className']);
+		foreach ($Model->hasAndBelongsToMany as $alias => $config) {
+			$className = pluginSplit($config['className']);
 			$className = $className[1];
-			if (!isset($record[$className]) || empty($record[$className])) {
+			if (!isset($record[$className])) {
+				continue;
+			}
+			if (empty($record[$className])) {
+				unset($record[$className]);
 				continue;
 			}
 
-			$joinInfo = Hash::extract($record[$className], '{n}.' . $val['with']);
-			if (empty($joinInfo)) {
+			// we might have HABTM values via a WITH alias
+			//   [Tag => [
+			//     [ArticlesTag => [...],
+			//     [ArticlesTag => [...],
+			//   ]]
+			$records = $this->_convertHabtmUsingWith($Model, $record[$className], $config);
+			if (!empty($records)) {
+				$record[$className] = $records;
 				continue;
 			}
 
-			foreach ($joinInfo as $joinKey => $joinVal) {
-				$joinInfo[$joinKey] = $this->_stripFields($Model, $joinVal);
-
-				if (array_key_exists($val['foreignKey'], $joinVal)) {
-					unset($joinInfo[$joinKey][$val['foreignKey']]);
-				}
+			// we might have HABTM values via a simple nested list
+			//   [Tag => [
+			//     [...],
+			//     [...],
+			//   ]]
+			$records = $this->_convertHabtmUsingAsIds($Model, $record[$className], $config);
+			if (!empty($records)) {
+				$record[$className] = $records;
+				continue;
 			}
 
-			$record[$className] = $joinInfo;
+			unset($record[$className]);
+
 		}
 
 		return $record;
+	}
+	protected function _convertHabtmUsingWith(Model $Model, $records, $config) {
+		$records = Hash::extract($records, '{n}.' . $config['with']);
+
+		foreach ($records as $joinKey => $joinVal) {
+			$records[$joinKey] = $this->_stripFields($Model, $joinVal);
+
+			if (array_key_exists($config['foreignKey'], $joinVal)) {
+				unset($records[$joinKey][$config['foreignKey']]);
+			}
+		}
+
+		return $records;
+	}
+	protected function _convertHabtmUsingAsIds(Model $Model, $records, $config) {
+		$ids = [];
+		foreach ($records as $joinKey => $joinVal) {
+			if (empty($joinVal['id'])) {
+				continue;
+			}
+			$ids[] = $joinVal['id'];
+		}
+
+		if (empty($ids)) {
+			return [];
+		}
+
+		return [$config['className'] => $ids];
 	}
 
 /**
  * Performs the actual creation and save.
  *
+ * This should only be done AFTER we have perpared/converted the record.
+ *
  * @param object $Model Model object
+ * @param array $record full data record to save (converted)
  * @return mixed
  */
-	protected function _copyRecord(Model $Model) {
+	public function copySaveAll(Model $Model, $record) {
+		$settings = $this->settings($Model);
 		$Model->create();
+		$saved = $Model->saveAll($record, $settings['saveAllOptions']);
+		$id = $Model->id;
 
-		$saved = $Model->saveAll($this->record, array(
-			'validate' => false,
-			'deep' => true
-		));
-
-		if ($this->settings[$Model->alias]['masterKey']) {
-			$record = $this->_updateMasterKey($Model);
-			$Model->saveAll($record, array(
-				'validate' => false,
-				'deep' => true
-			));
+		if ($settings['masterKey']) {
+			$record = $this->_updateMasterKey($Model, $id);
+			$Model->saveAll($record, $settings['saveAllOptions']);
 		}
 		return $saved;
 	}
@@ -266,14 +466,8 @@ class CopyableBehavior extends ModelBehavior {
  * @param Model $Model
  * @return array
  */
-	protected function _updateMasterKey(Model $Model) {
-		$record = $Model->find('first', array(
-			'conditions' => array(
-				$Model->escapeField() => $Model->id
-			), 
-			'contain' => $this->contain
-		));
-
+	protected function _updateMasterKey(Model $Model, $id) {
+		$record = $Model->copyFindData($id, array());
 		$record = $this->_masterKeyLoop($Model, $record, $Model->id);
 		return $record;
 	}
@@ -287,6 +481,7 @@ class CopyableBehavior extends ModelBehavior {
  * @return array
  */
 	protected function _masterKeyLoop(Model $Model, $record, $id) {
+		$settings = $this->settings($Model);
 		foreach ($record as $key => $val) {
 			if (is_array($val)) {
 				if (empty($val)) {
@@ -299,35 +494,60 @@ class CopyableBehavior extends ModelBehavior {
 				}
 			}
 
-			if (!isset($val[$this->settings[$Model->alias]['masterKey']])) {
+			if (!isset($val[$settings['masterKey']])) {
 				continue;
 			}
 
-			$record[$this->settings[$Model->alias]['masterKey']] = $id;
+			$record[$settings['masterKey']] = $id;
 		}
 		return $record;
 	}
 
 /**
- * Generates a contain array for Containable behavior by
- * recursively looping through $Model->hasMany and
- * $Model->hasOne associations.
+ * Generates a contain array for Containable behavior by recursively looping through
+ * - $Model->hasMany associations
+ * - $Model->hasOne associations
  *
  * @param object $Model Model object
- * @return array
+ * @param array $contain
+ * @return array $contain
  */
-	protected function _recursiveChildContain(Model $Model) {
-		$contain = array();
-		if (!isset($this->settings[$Model->alias]) || !$this->settings[$Model->alias]['recursive']) {
+	protected function _generateContainHasRecursivly(Model $Model, $contain = array()) {
+		$settings = $this->settings($Model);
+		if (!isset($settings) || !$settings['recursive']) {
 			return $contain;
 		}
 
 		$children = array_merge(array_keys($Model->hasMany), array_keys($Model->hasOne));
 		foreach ($children as $child) {
 			if ($Model->alias == $child) {
+				// do not contain self
 				continue;
 			}
-			$contain[$child] = $this->_recursiveChildContain($Model->{$child});
+			// recursive contain these children's children
+			//   [Comment => [User => [Profile => []]]]
+			$contain[$child] = $this->_generateContainHasRecursivly($Model->{$child});
+		}
+
+		return $contain;
+	}
+
+/**
+ * Generates a contain array for Containable behavior by looking for only
+ * - $Model->hasAndBelongsToMany associations
+ *
+ * @param object $Model Model object
+ * @param array $contain
+ * @return array $contain
+ */
+	protected function _generateContainHABTM(Model $Model, $contain = array()) {
+		$settings = $this->settings($Model);
+		if (!isset($settings) || !$settings['habtm']) {
+			return $contain;
+		}
+
+		foreach (array_keys($Model->hasAndBelongsToMany) as $habtm) {
+			$contain[$habtm] = array();
 		}
 
 		return $contain;
@@ -342,7 +562,8 @@ class CopyableBehavior extends ModelBehavior {
  * @return array
  */
 	protected function _stripFields(Model $Model, $record) {
-		foreach ($this->settings[$Model->alias]['stripFields'] as $field) {
+		$settings = $this->settings($Model);
+		foreach ($settings['stripFields'] as $field) {
 			if (array_key_exists($field, $record)) {
 				unset($record[$field]);
 			}

--- a/Model/Behavior/CopyableBehavior.php
+++ b/Model/Behavior/CopyableBehavior.php
@@ -5,7 +5,7 @@
  * Adds ability to copy a model record, including all hasMany and hasAndBelongsToMany
  * associations. Relies on Containable behavior, which this behavior will attach
  * on the fly as needed.
- * 
+ *
  * HABTM relationships are just duplicated in the join table, while hasMany and hasOne
  * records are recursively copied as well.
  *
@@ -47,15 +47,15 @@ class CopyableBehavior extends ModelBehavior {
  * will look in the $this->contain array.
  */
 	protected $_defaults = array(
-		'recursive' => true, 
-		'habtm' => true, 
+		'recursive' => true,
+		'habtm' => true,
 		'stripFields' => array(
-			'id', 
-			'created', 
-			'modified', 
-			'lft', 
+			'id',
+			'created',
+			'modified',
+			'lft',
 			'rght'
-		), 
+		),
 		'ignore' => array(
 		),
 		'masterKey' => null
@@ -85,7 +85,7 @@ class CopyableBehavior extends ModelBehavior {
 		$this->record = $Model->find('first', array(
 			'conditions' => array(
 				$Model->alias . '.id' => $id
-			), 
+			),
 			'contain' => $this->contain
 		));
 
@@ -118,7 +118,7 @@ class CopyableBehavior extends ModelBehavior {
 	}
 
 /**
- * Removes any ignored associations, as defined in the model settings, from 
+ * Removes any ignored associations, as defined in the model settings, from
  * the $this->contain array.
  *
  * @param object $Model Model object
@@ -202,7 +202,8 @@ class CopyableBehavior extends ModelBehavior {
  * HABTM join tables may contain extra information (sorting
  * order, etc).
  *
- * @param object $Model Model object
+ * @param Model $Model Model object
+ * @param array $record
  * @return array modified $record
  */
 	protected function _convertHabtm(Model $Model, $record) {
@@ -220,15 +221,15 @@ class CopyableBehavior extends ModelBehavior {
 			if (empty($joinInfo)) {
 				continue;
 			}
-			
+
 			foreach ($joinInfo as $joinKey => $joinVal) {
 				$joinInfo[$joinKey] = $this->_stripFields($Model, $joinVal);
-				
+
 				if (array_key_exists($val['foreignKey'], $joinVal)) {
 					unset($joinInfo[$joinKey][$val['foreignKey']]);
 				}
 			}
-			
+
 			$record[$className] = $joinInfo;
 		}
 
@@ -262,14 +263,14 @@ class CopyableBehavior extends ModelBehavior {
 /**
  * Runs through to update the master key for deep copying.
  *
- * @param object model
+ * @param Model $Model
  * @return array
- */	
+ */
 	protected function _updateMasterKey(Model $Model) {
 		$record = $Model->find('first', array(
 			'conditions' => array(
 				$Model->alias . '.id' => $Model->id
-			), 
+			),
 			'contain' => $this->contain
 		));
 
@@ -280,9 +281,9 @@ class CopyableBehavior extends ModelBehavior {
 /**
  * Called by _updateMasterKey as part of the copying process for deep recursion.
  *
- * @param oject model
- * @param array record
- * @param integer id
+ * @param Model $Model
+ * @param array $record
+ * @param integer $id
  * @return array
  */
 	protected function _masterKeyLoop(Model $Model, $record, $id) {
@@ -363,5 +364,5 @@ class CopyableBehavior extends ModelBehavior {
 
 		return true;
 	}
-	
+
 }

--- a/Model/Behavior/CopyableBehavior.php
+++ b/Model/Behavior/CopyableBehavior.php
@@ -451,8 +451,8 @@ class CopyableBehavior extends ModelBehavior {
 			$habtm = $this->_convertHabtmUsingWith($Model, $record[$className], $config);
 			if (!empty($habtm)) {
 				// now [ArticlesTag => [...]]
-				$record = array_merge($record, $habtm);
 				unset($record[$className]);
+				$record = array_merge($record, $habtm);
 				continue;
 			}
 

--- a/Model/Behavior/CopyableBehavior.php
+++ b/Model/Behavior/CopyableBehavior.php
@@ -84,7 +84,7 @@ class CopyableBehavior extends ModelBehavior {
 		$this->generateContain($Model);
 		$this->record = $Model->find('first', array(
 			'conditions' => array(
-				$Model->alias . '.id' => $id
+				$Model->escapeField() => $id
 			), 
 			'contain' => $this->contain
 		));
@@ -130,8 +130,8 @@ class CopyableBehavior extends ModelBehavior {
 		}
 		$ignore = array_unique($this->settings[$Model->alias]['ignore']);
 		foreach ($ignore as $path) {
-			if (Set::check($this->contain, $path)) {
-				$this->contain = Set::remove($this->contain, $path);
+			if (Hash::check($this->contain, $path)) {
+				$this->contain = Hash::remove($this->contain, $path);
 			}
 		}
 		return true;
@@ -216,7 +216,7 @@ class CopyableBehavior extends ModelBehavior {
 				continue;
 			}
 
-			$joinInfo = Set::extract($record[$className], '{n}.' . $val['with']);
+			$joinInfo = Hash::extract($record[$className], '{n}.' . $val['with']);
 			if (empty($joinInfo)) {
 				continue;
 			}
@@ -268,7 +268,7 @@ class CopyableBehavior extends ModelBehavior {
 	protected function _updateMasterKey(Model $Model) {
 		$record = $Model->find('first', array(
 			'conditions' => array(
-				$Model->alias . '.id' => $Model->id
+				$Model->escapeField() => $Model->id
 			), 
 			'contain' => $this->contain
 		));

--- a/README
+++ b/README
@@ -1,3 +1,0 @@
-Adds recursive record copying to CakePHP
-For more information:
-http://jamienay.com/2010/03/copyable-behavior-for-cakephp-1-3-recursive-record-copying

--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+# Recursive Copy for CakePHP
+
+If you have a (deeply) nested tree of data, a model with several
+hasMany and hasAndBelongsToMany associaitons...
+you can not simply find() and then save()...
+
+To copy, you need to clear out the ID to create the new record...
+but then you have to do that for all of the associated records too.
+
+And you have to make sure that the newly creataed associated records are in fact,
+associated correctly with the new record.
+
+## Install
+
+```
+cd path/to/app
+git submodule add https://github.com/jamienay/copyable_behavior.git Plugin/Copyable
+```
+or
+```
+cd path/to/app
+git clone https://github.com/jamienay/copyable_behavior.git Plugin/Copyable
+```
+
+## Configure
+
+`app/Config/bootstrap.php`
+
+```
+	CakePlugin::load('Copyable');
+```
+
+And for every Model you want to use this on,
+you will need to setup the behavior with specific settings (see Usage).
+
+## Usage - Setup
+
+On any Model - you must first initialize the CopyableBehavior
+
+```
+public $actsAs = array(
+	'Copyable.Copyable' => array(),
+);
+```
+
+You may want to customize any of the settings for this Model
+
+```
+public $actsAs = array(
+	'Copyable.Copyable' => array(
+		// recursive: whether to copy hasMany and hasOne records
+		'recursive' => true,
+		// habtm: whether to copy hasAndBelongsToMany associations
+		'habtm' => true,
+		// stripFields: fields to strip during copy process
+		'stripFields' => array(
+			'id',
+			'created',
+			'modified',
+			'lft',
+			'rght'
+		),
+		// ignore: aliases of any associations that should be ignored, using dot (.) notation.
+		'ignore' => array(
+		),
+		// ?
+		'masterKey' => null
+	),
+);
+```
+
+## Usage - Perform Copy
+
+```
+if (!$this->MyModel->copy($id)) {
+	throw new CakeException("Unable to copy {$this->MyModel->alias} #{$id}");
+}
+$newId = $this->MyModel->id;
+```
+
+$id = the id of the record to be copied (int or uuid)
+
+### Primary Public Method:
+
+```
+*   copy($id, $settings)   --> $saved
+```
+
+
+### Secondary Public Methods:
+
+```
+*   copyGenerateContain()  --> $contain (from settings, or generated)
+*   copyFindData($id)      --> $data    (find first w/ contains)
+*   copyPrepareData($data) --> $data    (convert data w/o foreignKey/stripFields)
+*   copySaveAll($data)     --> $saved   (do saveAll and update masterKey)
+```
+
+## Background Information
+
+Adds recursive record copying to CakePHP
+For more information:
+http://jamienay.com/2010/03/copyable-behavior-for-cakephp-1-3-recursive-record-copying

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can pass in any and all settings at runtime like so:
 $settings = array(
 	'contain' => array('Foo', 'Foo.Bar'),
 	'saveAllOptions' => array('deep' => true, 'atomic' => true, 'validate' => true, 'callbacks' => false),
+	'stripFields' => array('id', 'created', 'modified', 'updated', 'my_unique_field')
 );
 if (!$this->MyModel->copy($id, $settings)) {
 	throw new CakeException("Unable to copy {$this->MyModel->alias} #{$id} with custom settings");
@@ -92,21 +93,35 @@ if (!$this->MyModel->copy($id, $settings)) {
 $newId = $this->MyModel->id;
 ```
 
-You can also pass in an `inject` setting, which will overwrite values after
+You can also pass in *inject setting*,
+which will overwrite values after
 `copyPrepareData()` but before `copySaveAll()`
 
 This is great if you want to default/change your data for the `copy()` but don't
 want to have to edit after the copy... (important for unique fields)
 
+
+We support two types of injections:
+
+* `merge` uses `Hash::merge()` to merge / overwrite basic nested arrays
+  (simple, but doesn't work great for hasMany records)
+* `insert` uses `Hash::insert()` to overwrite every instance matching a path
+  (great for hasMany records)
+
 ```
 $settings = array(
-	'inject' => array(
+	'merge' => array(
 		'MyModel' => array(
 			'unique_field' => 'newValue',
 			'parent_id' => $id,
 			'copied_on' => date('Y-m-d H:i:s'),
 			'copied_by' => $user_id,
 		)
+	),
+	'insert' => array(
+		'MyHasManyChild.{n}.field1' => null,
+		'MyHasManyChild.{n}.copied_on' => date('Y-m-d H:i:s'),
+		'MyHasManyChild.{n}.copied_by' => $user_id,
 	)
 );
 if (!$this->MyModel->copy($id, $settings)) {
@@ -116,20 +131,17 @@ $newId = $this->MyModel->id;
 ```
 
 
-### Primary Public Method:
+### Public Methods:
 
 ```
-*   copy($id, $settings)   --> $saved
-```
-
-
-### Secondary Public Methods:
-
-```
-*   copyGenerateContain()  --> $contain (from settings, or generated)
-*   copyFindData($id)      --> $data    (find first w/ contains)
-*   copyPrepareData($data) --> $data    (convert data w/o foreignKey/stripFields)
-*   copySaveAll($data)     --> $saved   (do saveAll and update masterKey)
+ * Primary Public Method:
+ *   copy($id, $settings)     --> $saved
+ *
+ * Secondary Public Methods:
+ *   copyGenerateContain()    --> $contain (from settings, or generated)
+ *   copyFindData($id)        --> $record    (find first w/ contains)
+ *   copyPrepareData($record) --> $record    (convert data w/o foreignKey/stripFields)
+ *   copySaveAll($record)     --> $saved   (do saveAll and update masterKey)
 ```
 
 ## Background Information

--- a/README.md
+++ b/README.md
@@ -72,13 +72,49 @@ public $actsAs = array(
 ## Usage - Perform Copy
 
 ```
+// $id = the id of the record to be copied (int or uuid)
 if (!$this->MyModel->copy($id)) {
 	throw new CakeException("Unable to copy {$this->MyModel->alias} #{$id}");
 }
 $newId = $this->MyModel->id;
 ```
 
-$id = the id of the record to be copied (int or uuid)
+You can pass in any and all settings at runtime like so:
+
+```
+$settings = array(
+	'contain' => array('Foo', 'Foo.Bar'),
+	'saveAllOptions' => array('deep' => true, 'atomic' => true, 'validate' => true, 'callbacks' => false),
+);
+if (!$this->MyModel->copy($id, $settings)) {
+	throw new CakeException("Unable to copy {$this->MyModel->alias} #{$id} with custom settings");
+}
+$newId = $this->MyModel->id;
+```
+
+You can also pass in an `inject` setting, which will overwrite values after
+`copyPrepareData()` but before `copySaveAll()`
+
+This is great if you want to default/change your data for the `copy()` but don't
+want to have to edit after the copy... (important for unique fields)
+
+```
+$settings = array(
+	'inject' => array(
+		'MyModel' => array(
+			'unique_field' => 'newValue',
+			'parent_id' => $id,
+			'copied_on' => date('Y-m-d H:i:s'),
+			'copied_by' => $user_id,
+		)
+	)
+);
+if (!$this->MyModel->copy($id, $settings)) {
+	throw new CakeException("Unable to copy {$this->MyModel->alias} #{$id} with injected data");
+}
+$newId = $this->MyModel->id;
+```
+
 
 ### Primary Public Method:
 

--- a/Test/Case/Model/Behavior/CopyableBehaviorTest.php
+++ b/Test/Case/Model/Behavior/CopyableBehaviorTest.php
@@ -310,6 +310,8 @@ class CopyableBehaviorTest extends CakeTestCase {
 		'core.article_featureds_tags',
 		'core.category',
 		'core.attachment',
+		'plugin.copyable.widget',
+		'plugin.copyable.articles_widget',
 	);
 
 /**
@@ -563,7 +565,6 @@ class CopyableBehaviorTest extends CakeTestCase {
 				),
 			),
 		);
-		//echo var_export($result);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -573,7 +574,274 @@ class CopyableBehaviorTest extends CakeTestCase {
  * @return void
  */
 	public function testCopyPrepareDataHABTMViaWith() {
-		// todo
+		$this->Article->bindModel(
+			array(
+				'hasMany' => array(
+					'ArticlesWidget' => array()
+				),
+				'hasAndBelongsToMany' => array(
+					'Widget' => array('with' => 'ArticlesWidget')
+				),
+			),
+			false
+		);
+		$this->Article->ArticlesWidget->bindModel(
+			array(
+				'belongsTo' => array(
+					'Article' => array(),
+					'Widget' => array(),
+				),
+			),
+			false
+		);
+		$this->Article->Widget->bindModel(
+			array(
+				'hasMany' => array(
+					'ArticlesWidget' => array(),
+				),
+			),
+			false
+		);
+		$before = $this->Article->find('first', array(
+			'contain' => array(
+				'Widget',
+				'Widget.ArticlesWidget',
+			),
+			'recursive' => -1,
+		));
+		$this->assertEquals(
+			$before,
+			array(
+				'Article' => array(
+					'id' => '1',
+					'user_id' => '1',
+					'title' => 'First Article',
+					'body' => 'First Article Body',
+					'published' => 'Y',
+					'created' => '2007-03-18 10:39:23',
+					'updated' => '2007-03-18 10:41:31'
+				),
+				'Widget' => array(
+					(int) 0 => array(
+						'id' => '1',
+						'name' => 'Widget 1',
+						'ArticlesWidget' => array(
+							'id' => '1',
+							'article_id' => '1',
+							'widget_id' => '1',
+							'order' => '1',
+							'status' => 'good',
+							(int) 0 => array(
+								'id' => '1',
+								'article_id' => '1',
+								'widget_id' => '1',
+								'order' => '1',
+								'status' => 'good'
+							)
+						)
+					),
+					(int) 1 => array(
+						'id' => '2',
+						'name' => 'Widget 2',
+						'ArticlesWidget' => array(
+							'id' => '2',
+							'article_id' => '1',
+							'widget_id' => '2',
+							'order' => '2',
+							'status' => 'maybe',
+							(int) 0 => array(
+								'id' => '2',
+								'article_id' => '1',
+								'widget_id' => '2',
+								'order' => '2',
+								'status' => 'maybe'
+							)
+						)
+					),
+					(int) 2 => array(
+						'id' => '3',
+						'name' => 'Widget 3',
+						'ArticlesWidget' => array(
+							'id' => '3',
+							'article_id' => '1',
+							'widget_id' => '3',
+							'order' => '3',
+							'status' => 'bad',
+							(int) 0 => array(
+								'id' => '3',
+								'article_id' => '1',
+								'widget_id' => '3',
+								'order' => '3',
+								'status' => 'bad'
+							)
+						)
+					)
+				)
+			)
+		);
+		$result = $this->Article->copyPrepareData($before);
+		$expected = array(
+			'Article' => array(
+				'user_id' => '1',
+				'title' => 'First Article',
+				'body' => 'First Article Body',
+				'published' => 'Y',
+				'updated' => '2007-03-18 10:41:31'
+			),
+			// handles as hasMany (nested)
+			'ArticlesWidget' => array(
+				array(
+					'widget_id' => '1',
+					'order' => '1',
+					'status' => 'good',
+					(int) 0 => array(
+						'id' => '1',
+						'article_id' => '1',
+						'widget_id' => '1',
+						'order' => '1',
+						'status' => 'good'
+					)
+				),
+				array(
+					'widget_id' => '2',
+					'order' => '2',
+					'status' => 'maybe',
+					(int) 0 => array(
+						'id' => '2',
+						'article_id' => '1',
+						'widget_id' => '2',
+						'order' => '2',
+						'status' => 'maybe'
+					)
+				),
+				array(
+					'widget_id' => '3',
+					'order' => '3',
+					'status' => 'bad',
+					(int) 0 => array(
+						'id' => '3',
+						'article_id' => '1',
+						'widget_id' => '3',
+						'order' => '3',
+						'status' => 'bad'
+					)
+				)
+			),
+		);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * test preparation of data for full, nested values - with HABTM via With as hasMany
+ *
+ * @return void
+ */
+	public function testCopyPrepareDataHABTMViaWithAsHasMany() {
+		$this->Article->bindModel(
+			array(
+				'hasMany' => array(
+					'ArticlesWidget' => array()
+				),
+				'hasAndBelongsToMany' => array(
+					'Widget' => array('with' => 'ArticlesWidget')
+				),
+			),
+			false
+		);
+		$this->Article->ArticlesWidget->bindModel(
+			array(
+				'belongsTo' => array(
+					'Article' => array(),
+					'Widget' => array(),
+				),
+			),
+			false
+		);
+		$before = $this->Article->find('first', array(
+			'contain' => array(
+				'ArticlesWidget',
+				'ArticlesWidget.Widget',
+			),
+			'recursive' => -1,
+		));
+		$this->assertEquals(
+			$before,
+			array(
+				'Article' => array(
+					'id' => '1',
+					'user_id' => '1',
+					'title' => 'First Article',
+					'body' => 'First Article Body',
+					'published' => 'Y',
+					'created' => '2007-03-18 10:39:23',
+					'updated' => '2007-03-18 10:41:31'
+				),
+				'ArticlesWidget' => array(
+					array(
+						'id' => '1',
+						'article_id' => '1',
+						'widget_id' => '1',
+						'order' => '1',
+						'status' => 'good',
+						'Widget' => array(
+							'id' => '1',
+							'name' => 'Widget 1'
+						)
+					),
+					array(
+						'id' => '2',
+						'article_id' => '1',
+						'widget_id' => '2',
+						'order' => '2',
+						'status' => 'maybe',
+						'Widget' => array(
+							'id' => '2',
+							'name' => 'Widget 2'
+						)
+					),
+					array(
+						'id' => '3',
+						'article_id' => '1',
+						'widget_id' => '3',
+						'order' => '3',
+						'status' => 'bad',
+						'Widget' => array(
+							'id' => '3',
+							'name' => 'Widget 3'
+						)
+					)
+				)
+			)
+		);
+		$result = $this->Article->copyPrepareData($before);
+		$expected = array(
+			'Article' => array(
+				'user_id' => '1',
+				'title' => 'First Article',
+				'body' => 'First Article Body',
+				'published' => 'Y',
+				'updated' => '2007-03-18 10:41:31'
+			),
+			// handles as hasMany (nested)
+			'ArticlesWidget' => array(
+				array(
+					'widget_id' => '1',
+					'order' => '1',
+					'status' => 'good',
+				),
+				array(
+					'widget_id' => '2',
+					'order' => '2',
+					'status' => 'maybe',
+				),
+				array(
+					'widget_id' => '3',
+					'order' => '3',
+					'status' => 'bad',
+				)
+			)
+		);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/Test/Case/Model/Behavior/CopyableBehaviorTest.php
+++ b/Test/Case/Model/Behavior/CopyableBehaviorTest.php
@@ -812,12 +812,16 @@ class CopyableBehaviorTest extends CakeTestCase {
 		);
 
 		$customSettings = array(
-			'inject' => array(
+			'merge' => array(
 				'Article' => array(
 					'title' => 'INJECT changed this',
 					'published' => 'X',
 				)
-			)
+			),
+			'insert' => array(
+				'Comment.{n}.user_id' => 0,
+				'Comment.{n}.comment' => 'INJECT changed via Hash::insert()',
+			),
 		);
 		$result = $this->Article->copy(1, $customSettings);
 		$this->assertTrue($result);
@@ -868,9 +872,14 @@ class CopyableBehaviorTest extends CakeTestCase {
 			)
 		));
 
-		// Inject changed expectations
-		$expected['Article']['title'] = $customSettings['inject']['Article']['title'];
-		$expected['Article']['published'] = $customSettings['inject']['Article']['published'];
+		// Inject changed expectations via Hash::merge()
+		$expected['Article']['title'] = $customSettings['merge']['Article']['title'];
+		$expected['Article']['published'] = $customSettings['merge']['Article']['published'];
+		// Inject changed expectations via Hash::insert()
+		foreach ($expected['Comment'] as $i => $data) {
+			$expected['Comment'][$i]['user_id'] = $customSettings['insert']['Comment.{n}.user_id'];
+			$expected['Comment'][$i]['comment'] = $customSettings['insert']['Comment.{n}.comment'];
+		}
 		$this->_assertArticleAfterCopy($result, $expected);
 	}
 

--- a/Test/Case/Model/Behavior/CopyableBehaviorTest.php
+++ b/Test/Case/Model/Behavior/CopyableBehaviorTest.php
@@ -1,0 +1,880 @@
+<?php
+/* Copyable Test cases generated on: 2013-09-26 10:09:29 : 1380204749*/
+App::uses('CopyableBehavior', 'Copyable.Model/Behavior');
+App::uses('Model', 'Model');
+App::uses('AppModel', 'Model');
+
+
+/**
+ * Article class
+ *
+ * @package       Cake.Test.Case.Model
+ * /
+class Article extends CakeTestModel {
+	public $name = 'Article';
+	public $belongsTo = array('User');
+	public $hasMany = array('Comment' => array('dependent' => true));
+	public $hasAndBelongsToMany = array('Tag');
+	public $actsAs = array(
+		'Copyable.Copyable' => array()
+	);
+}
+/* -- */
+
+require(CAKE . 'Test' . DS . 'Case' . DS . 'Model' . DS . 'models.php');
+
+
+class CopyableBehaviorTest extends CakeTestCase {
+
+
+/**
+ * Whether backup global state for each test method or not
+ *
+ * @var bool
+ */
+	public $backupGlobals = false;
+/**
+ * settings property
+ *
+ * @var array
+ */
+	public $settings = array(
+		'containArticle' => array(
+			// belongsTo
+			'User',
+			// hasOne
+			'Featured',
+			// hasOne -> belongsTo
+			'Featured.ArticleFeatured',
+			// hasMany
+			'Comment',
+			// hasMany -> belongsTo
+			'Comment.User',
+			// hasAndBelongsToMany
+			'Tag',
+		),
+	);
+
+/**
+ * settings property
+ *
+ * @var array
+ */
+		public $expectedFromFixtures = array(
+			0 => array(
+				'Article' => array(
+					'id' => '1',
+					'user_id' => '1',
+					'title' => 'First Article',
+					'body' => 'First Article Body',
+					'published' => 'Y',
+					'created' => '2007-03-18 10:39:23',
+					'updated' => '2007-03-18 10:41:31',
+				),
+				'User' => array(
+					'id' => '1',
+					'user' => 'mariano',
+					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+					'created' => '2007-03-17 01:16:23',
+					'updated' => '2007-03-17 01:18:31',
+				),
+				'Featured' => array(
+					'id' => '1',
+					'article_featured_id' => '1',
+					'category_id' => '1',
+					'published_date' => '2007-03-31 10:39:23',
+					'end_date' => '2007-05-15 10:39:23',
+					'created' => '2007-03-18 10:39:23',
+					'updated' => '2007-03-18 10:41:31',
+					'ArticleFeatured' => array(
+						'id' => '1',
+						'user_id' => '1',
+						'title' => 'First Article',
+						'body' => 'First Article Body',
+						'published' => 'Y',
+						'created' => '2007-03-18 10:39:23',
+						'updated' => '2007-03-18 10:41:31',
+					),
+				),
+				'Comment' => array(
+					0 => array(
+						'id' => '1',
+						'article_id' => '1',
+						'user_id' => '2',
+						'comment' => 'First Comment for First Article',
+						'published' => 'Y',
+						'created' => '2007-03-18 10:45:23',
+						'updated' => '2007-03-18 10:47:31',
+						'User' => array(
+							'id' => '2',
+							'user' => 'nate',
+							'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+							'created' => '2007-03-17 01:18:23',
+							'updated' => '2007-03-17 01:20:31',
+						),
+					),
+					1 => array(
+						'id' => '2',
+						'article_id' => '1',
+						'user_id' => '4',
+						'comment' => 'Second Comment for First Article',
+						'published' => 'Y',
+						'created' => '2007-03-18 10:47:23',
+						'updated' => '2007-03-18 10:49:31',
+						'User' => array(
+							'id' => '4',
+							'user' => 'garrett',
+							'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+							'created' => '2007-03-17 01:22:23',
+							'updated' => '2007-03-17 01:24:31',
+						),
+					),
+					2 => array(
+						'id' => '3',
+						'article_id' => '1',
+						'user_id' => '1',
+						'comment' => 'Third Comment for First Article',
+						'published' => 'Y',
+						'created' => '2007-03-18 10:49:23',
+						'updated' => '2007-03-18 10:51:31',
+						'User' => array(
+							'id' => '1',
+							'user' => 'mariano',
+							'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+							'created' => '2007-03-17 01:16:23',
+							'updated' => '2007-03-17 01:18:31',
+						),
+					),
+					3 => array(
+						'id' => '4',
+						'article_id' => '1',
+						'user_id' => '1',
+						'comment' => 'Fourth Comment for First Article',
+						'published' => 'N',
+						'created' => '2007-03-18 10:51:23',
+						'updated' => '2007-03-18 10:53:31',
+						'User' => array(
+							'id' => '1',
+							'user' => 'mariano',
+							'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+							'created' => '2007-03-17 01:16:23',
+							'updated' => '2007-03-17 01:18:31',
+						),
+					),
+				),
+				'Tag' => array(
+					0 => array(
+						'id' => '1',
+						'tag' => 'tag1',
+						'created' => '2007-03-18 12:22:23',
+						'updated' => '2007-03-18 12:24:31',
+					),
+					1 => array(
+						'id' => '2',
+						'tag' => 'tag2',
+						'created' => '2007-03-18 12:24:23',
+						'updated' => '2007-03-18 12:26:31',
+					),
+				),
+			),
+			1 => array(
+				'Article' => array(
+					'id' => '2',
+					'user_id' => '3',
+					'title' => 'Second Article',
+					'body' => 'Second Article Body',
+					'published' => 'Y',
+					'created' => '2007-03-18 10:41:23',
+					'updated' => '2007-03-18 10:43:31',
+				),
+				'User' => array(
+					'id' => '3',
+					'user' => 'larry',
+					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+					'created' => '2007-03-17 01:20:23',
+					'updated' => '2007-03-17 01:22:31',
+				),
+				'Featured' => array(
+					'id' => '2',
+					'article_featured_id' => '2',
+					'category_id' => '1',
+					'published_date' => '2007-03-31 10:39:23',
+					'end_date' => '2007-05-15 10:39:23',
+					'created' => '2007-03-18 10:39:23',
+					'updated' => '2007-03-18 10:41:31',
+					'ArticleFeatured' => array(
+						'id' => '2',
+						'user_id' => '3',
+						'title' => 'Second Article',
+						'body' => 'Second Article Body',
+						'published' => 'Y',
+						'created' => '2007-03-18 10:41:23',
+						'updated' => '2007-03-18 10:43:31',
+					),
+				),
+				'Comment' => array(
+					0 => array(
+						'id' => '5',
+						'article_id' => '2',
+						'user_id' => '1',
+						'comment' => 'First Comment for Second Article',
+						'published' => 'Y',
+						'created' => '2007-03-18 10:53:23',
+						'updated' => '2007-03-18 10:55:31',
+						'User' => array(
+							'id' => '1',
+							'user' => 'mariano',
+							'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+							'created' => '2007-03-17 01:16:23',
+							'updated' => '2007-03-17 01:18:31',
+						),
+					),
+					1 => array(
+						'id' => '6',
+						'article_id' => '2',
+						'user_id' => '2',
+						'comment' => 'Second Comment for Second Article',
+						'published' => 'Y',
+						'created' => '2007-03-18 10:55:23',
+						'updated' => '2007-03-18 10:57:31',
+						'User' => array(
+							'id' => '2',
+							'user' => 'nate',
+							'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+							'created' => '2007-03-17 01:18:23',
+							'updated' => '2007-03-17 01:20:31',
+						),
+					),
+				),
+				'Tag' => array(
+					0 => array(
+						'id' => '1',
+						'tag' => 'tag1',
+						'created' => '2007-03-18 12:22:23',
+						'updated' => '2007-03-18 12:24:31',
+					),
+					1 => array(
+						'id' => '3',
+						'tag' => 'tag3',
+						'created' => '2007-03-18 12:26:23',
+						'updated' => '2007-03-18 12:28:31',
+					),
+				),
+			), 2=> array(
+				'Article' => array(
+					'id' => '3',
+					'user_id' => '1',
+					'title' => 'Third Article',
+					'body' => 'Third Article Body',
+					'published' => 'Y',
+					'created' => '2007-03-18 10:43:23',
+					'updated' => '2007-03-18 10:45:31',
+				),
+				'User' => array(
+					'id' => '1',
+					'user' => 'mariano',
+					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
+					'created' => '2007-03-17 01:16:23',
+					'updated' => '2007-03-17 01:18:31',
+				),
+				'Featured' => array(
+					'id' => NULL,
+					'article_featured_id' => NULL,
+					'category_id' => NULL,
+					'published_date' => NULL,
+					'end_date' => NULL,
+					'created' => NULL,
+					'updated' => NULL,
+				),
+				'Comment' => array(
+				),
+				'Tag' => array(
+				),
+			),
+		);
+
+
+/**
+ * fixtures property
+ *
+ * @var array
+ */
+	public $fixtures = array(
+		'core.article',
+		'core.user',
+		'core.comment',
+		'core.tag',
+		'core.articles_tag',
+		'core.featured',
+		'core.article_featured',
+		'core.article_featureds_tags',
+		'core.category',
+		'core.attachment',
+	);
+
+/**
+ * Start Test callback
+ *
+ * @param string $method
+ * @return void
+ * @access public
+ */
+	public function startTest($method) {
+		parent::startTest($method);
+		$this->Article = new Article();
+		$this->Article->recursive = -1;
+		$this->Article->Behaviors->load('Containable', array());
+		$this->Article->Behaviors->load('Copyable.Copyable', array(
+			'habtm' => true,
+			'recursive' => true,
+			'contain' => $this->settings['containArticle'],
+		));
+
+		// Article isn't bound to anything via hasOne()
+		//   so this is a hack to bind it to
+		//     hasOne Featured via article_featured_id
+		$this->Article->Featured = ClassRegistry::init('Featured');
+		$this->Article->bindModel(
+			array(
+				'hasOne' => array(
+					'Featured' => array(
+						'className' => 'Featured',
+						'foreignKey' => 'article_featured_id',
+					)
+				)
+			),
+			false
+		);
+
+		/*
+		$this->ArticleFeatured = new Article();
+		$this->ArticleFeatured->recursive = -1;
+		$this->ArticleFeatured->Behaviors->load('Containable');
+		$this->ArticleFeatured->Behaviors->load('Copyable.Copyable', array());
+		*/
+	}
+
+/**
+ * End Test callback
+ *
+ * @param string $method
+ * @return void
+ * @access public
+ */
+	public function endTest($method) {
+		parent::endTest($method);
+		unset($this->Article);
+		ClassRegistry::flush();
+	}
+
+/**
+ * test this Test's Setup/data
+ *
+ * @return void
+ */
+	public function testSetupArticleFeatured() {
+		$result = $this->Article->find('all', array(
+			'contain' => $this->settings['containArticle'],
+		));
+		//echo var_export($result);
+		$expected = $this->expectedFromFixtures;
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * test settings
+ *
+ * @return void
+ */
+	public function testSettings() {
+		// todo - will have to make a mock class to get access to settings
+	}
+
+/**
+ * test settings
+ *
+ * @return void
+ */
+	public function testCopyGenerateContain() {
+
+		// default settings - (when loaded/setup) - use them
+		// set onto the Behavior as if configured on setup
+		$settings = $this->Article->Behaviors->Copyable->settings['Article'];
+		$this->assertEquals(
+			$this->Article->copyGenerateContain(),
+			$settings['contain']
+		);
+
+		// custom settings - use them
+		$settings = array(
+			'contain' => array(
+				'Featured' => array(),
+				'Featured.ArticleFeatured' => array(),
+				'Comment' => array(),
+				'Tag' => array(),
+				'Tag.User' => array(),
+				'Foobar' => array(),
+			)
+		);
+		// set onto the Behavior as if configured on setup
+		$this->Article->Behaviors->Copyable->settings['Article'] = $settings;
+		$this->assertEquals(
+			$this->Article->copyGenerateContain(),
+			$settings['contain']
+		);
+
+		// remove contain from settings on the Behavior as if never configured
+		$this->Article->Behaviors->Copyable->settings['Article'] = array(
+			'recursive' => true,
+			'habtm' => true,
+		);
+
+		// no settings -- generate it
+		$this->assertEquals(
+			$this->Article->copyGenerateContain(),
+			array(
+				// ignores belongsTo
+				// finds hasOne
+				'Featured' => array(),
+				// finds hasMany
+				'Comment' => array(
+					// recurses into it's hasOne/hasMany
+					'Attachment' => array(),
+				),
+				// finds hasAndBelongsToMany (but no recursion)
+				'Tag' => array(),
+			)
+		);
+
+		// set to not-recursive
+		$this->Article->Behaviors->Copyable->settings['Article'] = array(
+			'recursive' => false,
+			'habtm' => true,
+		);
+
+		// no settings -- generate it
+		$this->assertEquals(
+			$this->Article->copyGenerateContain(),
+			array(
+				// ignores belongsTo
+				// ignores hasOne
+				// ignores hasMany
+				// finds hasAndBelongsToMany (but no recursion)
+				'Tag' => array(),
+			)
+		);
+
+		// set to not-recursive & not-habtm
+		$this->Article->Behaviors->Copyable->settings['Article'] = array(
+			'recursive' => false,
+			'habtm' => false,
+		);
+
+		// no settings -- generate it
+		$this->assertEquals(
+			$this->Article->copyGenerateContain(),
+			array(
+				// ignores belongsTo
+				// ignores hasOne
+				// ignores hasMany
+				// ignores hasAndBelongsToMany (but no recursion)
+			)
+		);
+	}
+
+/**
+ * test copyableFindData() uses the settings/contain to find a record
+ * and all children (in Containable hierarchy)
+ *
+ * @return void
+ */
+	public function testCopyFindData() {
+		$this->assertEquals(
+			$this->Article->copyFindData(1),
+			$this->expectedFromFixtures[0]
+		);
+	}
+
+/**
+ * test preparation of data for empty values
+ *
+ * @return void
+ */
+	public function testCopyPrepareDataEmpties() {
+		$this->assertEquals(
+			$this->Article->copyPrepareData(array()),
+			array()
+		);
+		$this->assertEquals(
+			$this->Article->copyPrepareData(null),
+			array()
+		);
+		$this->assertEquals(
+			$this->Article->copyPrepareData(false),
+			array()
+		);
+	}
+
+/**
+ * test preparation of data for full, nested values
+ *
+ * @return void
+ */
+	public function testCopyPrepareData1() {
+		$data = $this->expectedFromFixtures[1];
+		$result = $this->Article->copyPrepareData($data);
+		$expected = array(
+			'Article' => array(
+				'user_id' => '3',
+				'title' => 'Second Article',
+				'body' => 'Second Article Body',
+				'published' => 'Y',
+				'updated' => '2007-03-18 10:43:31',
+			),
+			// strips User (belongsTo)
+			'Featured' => array(
+				'category_id' => '1',
+				'published_date' => '2007-03-31 10:39:23',
+				'end_date' => '2007-05-15 10:39:23',
+				'updated' => '2007-03-18 10:41:31',
+				// strips ArticleFeatured (belongsTo)
+			),
+			'Comment' => array(
+				0 => array(
+					'user_id' => '1',
+					'comment' => 'First Comment for Second Article',
+					'published' => 'Y',
+					'updated' => '2007-03-18 10:55:31',
+					// strips User (belongsTo)
+				),
+				1 => array(
+					'user_id' => '2',
+					'comment' => 'Second Comment for Second Article',
+					'published' => 'Y',
+					'updated' => '2007-03-18 10:57:31',
+					// strips User (belongsTo)
+				),
+			),
+			// HABTM switched to just the primary keys for Joins
+			'Tag' => array(
+				'Tag' => array(
+					0 => '1',
+					1 => '3',
+				),
+			),
+		);
+		//echo var_export($result);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * test preparation of data for full, nested values - with HABTM via With
+ *
+ * @return void
+ */
+	public function testCopyPrepareDataHABTMViaWith() {
+		// todo
+	}
+
+/**
+ * test copy save all
+ * - does save all, but no convert/prepare of data
+ * - does _updateMasterKey
+ *
+ * @return void
+ */
+	public function testCopySaveAll() {
+		$initialCounts = array(
+			'Article' => $this->Article->find('count'),
+			'User' => $this->Article->User->find('count'),
+			'Featured' => $this->Article->Featured->find('count'),
+			'Comment' => $this->Article->Comment->find('count'),
+			'Tag' => $this->Article->Tag->find('count'),
+		);
+		$before = $this->Article->copyFindData(1);
+		$save = $before;
+		unset($save['Tag']);
+		$saved = $this->Article->copySaveAll($save);
+		$this->assertTrue($saved);
+
+		$id = $this->Article->id;
+		$this->assertEquals($id, 1);
+
+		$after = $this->Article->copyFindData(1);
+		$this->assertEquals($before, $after);
+
+		$this->assertEquals(
+			array(
+				'Article' => $this->Article->find('count'),
+				'User' => $this->Article->User->find('count'),
+				'Featured' => $this->Article->Featured->find('count'),
+				'Comment' => $this->Article->Comment->find('count'),
+				'Tag' => $this->Article->Tag->find('count'),
+			),
+			$initialCounts
+		);
+	}
+
+/**
+ * test copy on fixture Article#1
+ *
+ * @return void
+ */
+	public function testCopy1() {
+		$initialCounts = array(
+			'Article' => $this->Article->find('count'),
+			'User' => $this->Article->User->find('count'),
+			'Featured' => $this->Article->Featured->find('count'),
+			'Comment' => $this->Article->Comment->find('count'),
+			'Tag' => $this->Article->Tag->find('count'),
+		);
+
+		$result = $this->Article->copy(1);
+		$this->assertTrue($result);
+
+		$newId = $this->Article->id;
+		$this->assertTrue(is_numeric($newId));
+
+		// orig is unchanged
+		$result = $this->Article->find('first', array(
+			'contain' => $this->settings['containArticle'],
+			'conditions' => array(
+				'Article.id' => 1
+			)
+		));
+		$expected = $this->expectedFromFixtures[0];
+		$this->assertEquals($expected, $result);
+
+		// see how many records were created
+		$this->assertEquals(
+			$this->Article->find('count'),
+			$initialCounts['Article'] + 1
+		);
+		$this->assertEquals(
+			$this->Article->User->find('count'),
+			$initialCounts['User']
+		);
+		$this->assertEquals(
+			$this->Article->Featured->find('count'),
+			$initialCounts['Featured'] + 1
+		);
+		$this->assertEquals(
+			$this->Article->Comment->find('count'),
+			$initialCounts['Comment'] + 4
+		);
+		// should not have made any more HABTM targets
+		//   should only have made more join records
+		$this->assertEquals(
+			$this->Article->Tag->find('count'),
+			$initialCounts['Tag']
+		);
+
+		// new record
+		$result = $this->Article->find('first', array(
+			'contain' => $this->settings['containArticle'],
+			'conditions' => array(
+				'Article.id' => $newId
+			)
+		));
+		$this->_assertArticleAfterCopy($result, $expected);
+	}
+
+/**
+ * test copy on fixture Article#2
+ *
+ * @return void
+ */
+	public function testCopy2() {
+		$initialCounts = array(
+			'Article' => $this->Article->find('count'),
+			'User' => $this->Article->User->find('count'),
+			'Featured' => $this->Article->Featured->find('count'),
+			'Comment' => $this->Article->Comment->find('count'),
+			'Tag' => $this->Article->Tag->find('count'),
+		);
+
+		$result = $this->Article->copy(2);
+		$this->assertTrue($result);
+
+		$newId = $this->Article->id;
+		$this->assertTrue(is_numeric($newId));
+
+		// orig is unchanged
+		$result = $this->Article->find('first', array(
+			'contain' => $this->settings['containArticle'],
+			'conditions' => array(
+				'Article.id' => 2
+			)
+		));
+		$expected = $this->expectedFromFixtures[1];
+		$this->assertEquals($expected, $result);
+
+		// see how many records were created
+		$this->assertEquals(
+			$this->Article->find('count'),
+			$initialCounts['Article'] + 1
+		);
+		$this->assertEquals(
+			$this->Article->User->find('count'),
+			$initialCounts['User']
+		);
+		$this->assertEquals(
+			$this->Article->Featured->find('count'),
+			$initialCounts['Featured'] + 1
+		);
+		$this->assertEquals(
+			$this->Article->Comment->find('count'),
+			$initialCounts['Comment'] + 2
+		);
+		// should not have made any more HABTM targets
+		//   should only have made more join records
+		$this->assertEquals(
+			$this->Article->Tag->find('count'),
+			$initialCounts['Tag']
+		);
+
+		// new record
+		$result = $this->Article->find('first', array(
+			'contain' => $this->settings['containArticle'],
+			'conditions' => array(
+				'Article.id' => $newId
+			)
+		));
+		$this->_assertArticleAfterCopy($result, $expected);
+	}
+
+/**
+ * test copy on fixture Article#3
+ *
+ * @return void
+ */
+	public function testCopy3() {
+		$initialCounts = array(
+			'Article' => $this->Article->find('count'),
+			'User' => $this->Article->User->find('count'),
+			'Featured' => $this->Article->Featured->find('count'),
+			'Comment' => $this->Article->Comment->find('count'),
+			'Tag' => $this->Article->Tag->find('count'),
+		);
+
+		$result = $this->Article->copy(3);
+		$this->assertTrue($result);
+
+		$newId = $this->Article->id;
+		$this->assertTrue(is_numeric($newId));
+
+		// orig is unchanged
+		$result = $this->Article->find('first', array(
+			'contain' => $this->settings['containArticle'],
+			'conditions' => array(
+				'Article.id' => 3
+			)
+		));
+		$expected = $this->expectedFromFixtures[2];
+		$this->assertEquals($expected, $result);
+
+		// see how many records were created
+		$this->assertEquals(
+			$this->Article->find('count'),
+			$initialCounts['Article'] + 1
+		);
+		$this->assertEquals(
+			$this->Article->User->find('count'),
+			$initialCounts['User']
+		);
+		$this->assertEquals(
+			$this->Article->Featured->find('count'),
+			$initialCounts['Featured']
+		);
+		$this->assertEquals(
+			$this->Article->Comment->find('count'),
+			$initialCounts['Comment']
+		);
+		$this->assertEquals(
+			$this->Article->Tag->find('count'),
+			$initialCounts['Tag']
+		);
+		$this->_assertArticleAfterCopy($result, $expected);
+	}
+
+
+
+/**
+ *
+ *
+ */
+	public function _assertArticleAfterCopy($result, $expected) {
+		// verify belongsTo
+		if (!(empty($result['User']) && empty($expected['User']))) {
+			$this->assertEquals(
+				Hash::extract($result, 'User.id'),
+				Hash::extract($expected, 'User.id'),
+				'belongsTo User.id should match expected (no new record)'
+			);
+			$this->assertEquals(
+				Hash::extract($result, 'User.user'),
+				Hash::extract($expected, 'User.user'),
+				'belongsTo User.user should match expected (no new record)'
+			);
+		}
+
+		// verify hasOne
+		if (!(empty($result['Featured']['id']) && empty($expected['Featured']['id']))) {
+			$this->assertNotEquals(
+				Hash::extract($result, 'Featured.id'),
+				Hash::extract($expected, 'Featured.id'),
+				'hasOne Featured.id should not match expected'
+			);
+			$this->assertEquals(
+				Hash::extract($result, 'Featured.category_id'),
+				Hash::extract($expected, 'Featured.category_id'),
+				'hasOne Featured.category_id should match expected'
+			);
+			$this->assertEquals(
+				Hash::extract($result, 'Featured.published_date'),
+				Hash::extract($expected, 'Featured.published_date'),
+				'hasOne Featured.published_date should match expected'
+			);
+		}
+
+		// verify hasMany
+		if (!(empty($result['Comment']) && empty($expected['Comment']))) {
+			$this->assertNotEquals(
+				Hash::extract($result, 'Comment.{n}.id'),
+				Hash::extract($expected, 'Comment.{n}.id'),
+				'hasMany Comment.{n}.id should not match expected'
+			);
+			$this->assertEquals(
+				Hash::extract($result, 'Comment.{n}.comment'),
+				Hash::extract($expected, 'Comment.{n}.comment'),
+				'hasMany Comment.{n}.comment should match expected'
+			);
+			$this->assertEquals(
+				Hash::extract($result, 'Comment.{n}.user_id'),
+				Hash::extract($expected, 'Comment.{n}.user_id'),
+				'hasMany Comment.{n}.user_id should match expected'
+			);
+			$this->assertEquals(
+				Hash::extract($result, 'Comment.{n}.published'),
+				Hash::extract($expected, 'Comment.{n}.published'),
+				'hasMany Comment.{n}.published should match expected'
+			);
+		}
+
+		// verify HABTM
+		if (!(empty($result['Tag']) && empty($expected['Tag']))) {
+			$this->assertEquals(
+				Hash::extract($result, 'Tag.{n}.id'),
+				Hash::extract($expected, 'Tag.{n}.id'),
+				'HABTM Tag.{n}.id should match expected (join table is the only new record)'
+			);
+			$this->assertEquals(
+				Hash::extract($result, 'Tag.{n}.tag'),
+				Hash::extract($expected, 'Tag.{n}.tag'),
+				'HABTM Tag.{n}.tag should match expected'
+			);
+		}
+	}
+
+
+}

--- a/Test/Fixture/ArticlesWidgetFixture.php
+++ b/Test/Fixture/ArticlesWidgetFixture.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyable Test Fixture
+ *
+ * PHP Version 5.4+
+ *
+ */
+class ArticlesWidgetFixture extends CakeTestFixture {
+
+/**
+ * Name
+ *
+ * @var string
+ * @access public
+ */
+	public $name = 'ArticlesWidget';
+
+/**
+ * Fields
+ *
+ * @var array
+ * @access public
+ */
+	public $fields = array(
+		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'unsigned' => false, 'key' => 'primary'),
+		'article_id' => array('type' => 'integer', 'null' => false, 'default' => null, 'unsigned' => false),
+		'widget_id' => array('type' => 'integer', 'null' => false, 'default' => null, 'unsigned' => false),
+		'order' => array('type' => 'integer', 'null' => false, 'default' => null, 'unsigned' => false),
+		'status' => array('type' => 'string', 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
+		'indexes' => array(
+			'PRIMARY' => array('column' => 'id', 'unique' => 1),
+			'article_id' => array('column' => array('article_id', 'status'), 'unique' => 0)
+		),
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_general_ci', 'engine' => 'InnoDB')
+	);
+
+/**
+ * Records
+ *
+ * @var array
+ * @access public
+ */
+	public $records = array(
+		array(
+			'id' => 1,
+			'article_id' => 1,
+			'widget_id' => 1,
+			'order' => 1,
+			'status' => 'good',
+		),
+		array(
+			'id' => 2,
+			'article_id' => 1,
+			'widget_id' => 2,
+			'order' => 2,
+			'status' => 'maybe',
+		),
+		array(
+			'id' => 3,
+			'article_id' => 1,
+			'widget_id' => 3,
+			'order' => 3,
+			'status' => 'bad',
+		),
+	);
+
+}

--- a/Test/Fixture/WidgetFixture.php
+++ b/Test/Fixture/WidgetFixture.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyable Test Fixture
+ *
+ * PHP Version 5.4+
+ *
+ */
+class WidgetFixture extends CakeTestFixture {
+
+/**
+ * Name
+ *
+ * @var string
+ * @access public
+ */
+	public $name = 'Widget';
+
+/**
+ * Fields
+ *
+ * @var array
+ * @access public
+ */
+	public $fields = array(
+		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'unsigned' => false, 'key' => 'primary'),
+		'name' => array('type' => 'string', 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
+		'indexes' => array(
+			'PRIMARY' => array('column' => 'id', 'unique' => 1),
+		),
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_general_ci', 'engine' => 'InnoDB')
+	);
+
+/**
+ * Records
+ *
+ * @var array
+ * @access public
+ */
+	public $records = array(
+		array(
+			'id' => 1,
+			'name' => 'Widget 1',
+		),
+		array(
+			'id' => 2,
+			'name' => 'Widget 2',
+		),
+		array(
+			'id' => 3,
+			'name' => 'Widget 3',
+		),
+	);
+
+}


### PR DESCRIPTION
I merged your project with my own implementation of something similar... 

I decided that this was worthwhile, benefiting from the "best of both" implementations.
- Now a Plugin (easier install, better isolation)
- Now you can pass in more settings, including your own custom `contain` and `saveAllOptions`
- Now more effectively recursive (resilient even if the behavior isn't setup on recursed models)
- Now you can inject (via Hash::merge & Hash::insert) before save - useful for data ceanup
- Now you can use your own custom `copyPrepareDataCustom()` method to custom-clean data if needed
- Now a few more methods are public, for possible direct usefulness and for easier testing (see README)
- Now tested...

```
$ ./cake test Copyable Model/Behavior/CopyableBehavior
---------------------------------------------------------------
CakePHP Test Shell
---------------------------------------------------------------
PHPUnit 3.7.38 by Sebastian Bergmann.

............

Time: 1.62 seconds, Memory: 22.25Mb

OK (12 tests, 98 assertions)
```
## Details
- [x] added unit testing for CopyableBehavior
- [x] switched to passing through the $record/$data vs keeping on Behavior
- [x] switched to passing through the $contain vs keeping on Behavior
- [x] switched to more dynamic settings - allows more recursion
    onto Models which don't have this Behavior setup/configured
- [x] switched to "sticky" settings - when used via copy()
    this takes priority over defaults, but not over per-Model settings
- [x] added support for custom settings for $contain (if set, does not generate)
- [x] added support for custom settings for $saveAllOptions
- [x] replaced old public generateContain() with copyGenerateContain()
    renamed to match public method "psuedo-namespacing" - prefixed w/ "copy"
    old alias retained for backwards compatibilty
- [x] exposed new public copyFindData() which does our lookup
- [x] exposed new public copyPrepareData() which does our conversion
- [x] exposed new public copySaveAll() which does our save
- [x] exposed new $Model->copyData array, for inspection of data before and after conversion
- [x] now we support data injection via merge or insert
- [x] put in default, empty settings for ^
- [x] replaced `$data` with `$record` for consistency
